### PR TITLE
Rework docking of apps

### DIFF
--- a/miriway_policy.h
+++ b/miriway_policy.h
@@ -69,6 +69,7 @@ private:
                                  miral::Window const& window);
     using workspace_list = std::list<std::shared_ptr<Workspace>>;
     void erase_if_empty(workspace_list::iterator const& old_workspace);
+    void dock_active_window_under_lock(MirPlacementGravity placement);
 
     ShellCommands* const commands;
 


### PR DESCRIPTION
Mir has implemented its own logic to doc windows, and that supports display reconfiguration. So let's use that instead of rolling our own.

Fixes: #12