### PR TITLE
Unsnap the launcher

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -32,7 +32,8 @@ xwayland-path=/snap/${SNAP_INSTANCE_NAME}/current/usr/bin/Xwayland
 ctrl-alt=t:miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/local/bin/miriway-terminal
 shell-component=swaybg -i ${background}
 shell-component=yambar --config="${yambar_config}"
-shell-meta=a:synapse
+shell-component=miriway-unsnap $SNAP/usr/bin/synapse --startup
+shell-meta=a:miriway-unsnap $SNAP/usr/bin/synapse
 
 meta=Left:@dock-left
 meta=Right:@dock-right
@@ -65,7 +66,7 @@ bar:
           string:
             text: " start"
             margin: 5
-            on-click: synapse
+            on-click: miriway-unsnap $SNAP/usr/bin/synapse
             deco: &greybg
               background:
                 color: 3f3f3fff


### PR DESCRIPTION
Empirically, this works across a range of systems: I assume because the DRI interface is stable enough to use the host drivers.

But... I can't find any reference to justify that assumption.

@RAOF is this a stupid idea, or is there a reason it should work?