### PR TITLE
Fix the mir-libs packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,10 +40,6 @@ parts:
       - enable-patchelf
     stage-snaps:
       - mir-libs/22/edge
-    stage:
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libgbm*
-      - -usr/lib/${CRAFT_ARCH_TRIPLET}/libglapi*
-      - -usr/share
     prime:
       - -*.h
       - -*.pc


### PR DESCRIPTION
This fixes the builds based on mir-libs. I've not isolated what things that were not staged are actually needed, as I don't think there's any reason to.