### PR TITLE
Unset GTK_IM_MODULE

### DIFF
--- a/miriway-shell.config
+++ b/miriway-shell.config
@@ -2,7 +2,7 @@ x11-window-title=Miriway
 idle-timeout=600
 ctrl-alt=t:miriway-terminal # Default "terminal emulator finder"
 
-app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
+app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none:-GTK_IM_MODULE
 shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 
 meta=Left:@dock-left


### PR DESCRIPTION
Having this set stops some GTK apps using the Wayland input methods we do support