### PR TITLE
snap: use the `/release` PPA by default

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ architectures:
 
 package-repositories:
   - type: apt
-    ppa: mir-team/rc
+    ppa: mir-team/release
 
 apps:
   miriway:


### PR DESCRIPTION
Let the tooling decide if it needs another.