### PR TITLE
Drop some shell protocol extensions (now they can be enabled in configuration)

### DIFF
--- a/miriway.cpp
+++ b/miriway.cpp
@@ -220,10 +220,7 @@ int main(int argc, char const* argv[])
     for (auto const& protocol : {
         WaylandExtensions::zwlr_layer_shell_v1,
         WaylandExtensions::zwlr_foreign_toplevel_manager_v1,
-        WaylandExtensions::zwp_virtual_keyboard_manager_v1,
-        WaylandExtensions::zwlr_virtual_pointer_manager_v1,
-        WaylandExtensions::ext_session_lock_manager_v1,
-        WaylandExtensions::zwp_input_method_manager_v2})
+        WaylandExtensions::ext_session_lock_manager_v1})
     {
         extensions.conditionally_enable(protocol, enable_for_shell_pids);
     }

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -219,8 +219,7 @@ int main(int argc, char const* argv[])
     // Protocols we're reserving for shell components_option
     for (auto const& protocol : {
         WaylandExtensions::zwlr_layer_shell_v1,
-        WaylandExtensions::zwlr_foreign_toplevel_manager_v1,
-        WaylandExtensions::ext_session_lock_manager_v1})
+        WaylandExtensions::zwlr_foreign_toplevel_manager_v1})
     {
         extensions.conditionally_enable(protocol, enable_for_shell_pids);
     }

--- a/snap-utils/bin/miriway.vnc-server
+++ b/snap-utils/bin/miriway.vnc-server
@@ -15,5 +15,7 @@ else
   miriway_config_file=/etc/xdg/xdg-miriway/miriway-shell.config
 fi
 
-grep ^shell-component= "${miriway_config_file}" | sed "s#^shell-component=\(.*\)#--shell-component=\'\1\'#" | \
-exec xargs env -u WAYLAND_DISPLAY $SNAP/usr/bin/xvfb-run "$@" --shell-component=ubuntu-frame-vnc
+sed --quiet -e "s#^shell-component=\(.*\)#--shell-component=\'\1\'#p" \
+-e "s#^shell-add-wayland-extension=\(.*\)#--shell-add-wayland-extension=\'\1\'#p" "${miriway_config_file}"| \
+exec xargs env -u WAYLAND_DISPLAY $SNAP/usr/bin/xvfb-run "$@" --shell-component=ubuntu-frame-vnc \
+--shell-add-wayland-extension=zwp_virtual_keyboard_manager_v1 --shell-add-wayland-extension=zwlr_virtual_pointer_manager_v1


### PR DESCRIPTION
Now we have `--shell-add-wayland-extension` we don't need to support as many by default.