### PR TITLE
Make possible configs compatible between snap and non-snap installs

### DIFF
--- a/miriway
+++ b/miriway
@@ -31,6 +31,8 @@ fi
 if command -v Xwayland > /dev/null
 then
   export MIR_SERVER_ENABLE_X11=1
+  MIR_SERVER_XWAYLAND_PATH=$(which Xwayland)
+  export MIR_SERVER_XWAYLAND_PATH
 fi
 
 # If there's an existing config missing any shell commands, then add them

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -27,7 +27,6 @@ x11-window-title=Miriway
 idle-timeout=600
 app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
 shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
-xwayland-path=/snap/${SNAP_INSTANCE_NAME}/current/usr/bin/Xwayland
 
 ctrl-alt=t:miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/local/bin/miriway-terminal
 shell-component=miriway-background ${background}


### PR DESCRIPTION
It is a PITA to keep configs in step between snap and local installs of Miriway: The snap needs to specify where Xwayland is, local installs don't.

So, make use the Snap environment instead of the .config and the .config  can "just work" for both