### PR TITLE
Fix background

### DIFF
--- a/example-configs/miriway-config-LXQT.bash
+++ b/example-configs/miriway-config-LXQT.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e ~/.config ]; then mkdir ~/.config; fi
+
 shell_components="lxqt-policykit qterminal lxqt-runner lxqt-panel swaybg lubuntu-artwork"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 

--- a/example-configs/miriway-config-MATE.bash
+++ b/example-configs/miriway-config-MATE.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e ~/.config ]; then mkdir ~/.config; fi
+
 shell_components="mate-panel mate-terminal swaybg /usr/libexec/mate-notification-daemon/mate-notification-daemon"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 

--- a/example-configs/miriway-config-SWAY.bash
+++ b/example-configs/miriway-config-SWAY.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e ~/.config ]; then mkdir ~/.config; fi
+
 shell_components="swaybg waybar wofi swaync kgx swaylock"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 waybar_config="${XDG_CONFIG_HOME:-$HOME/.config}/waybar/config"

--- a/example-configs/miriway-config-XFCE.bash
+++ b/example-configs/miriway-config-XFCE.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e ~/.config ]; then mkdir ~/.config; fi
+
 shell_components="swaybg xfce4-terminal xfce4-appfinder"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 

--- a/example-configs/miriway-config-alan_g.bash
+++ b/example-configs/miriway-config-alan_g.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+if [ ! -e ~/.config ]; then mkdir ~/.config; fi
+
 shell_components="yambar swaybg synapse kgx swaync grim swaylock gnome-keyring-daemon"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 yambar_config="${XDG_CONFIG_HOME:-$HOME/.config}/yambar/config.yml"


### PR DESCRIPTION
Snapcraft no longer includes $SNAP/bin in PATH

Also tweaked the examples to handle when ~/.config dosn't exist