### PR TITLE
core24

### DIFF
--- a/.github/workflows/refresh-downstreams.yml
+++ b/.github/workflows/refresh-downstreams.yml
@@ -3,7 +3,7 @@ name: Refresh downstreams
 on:
   push:
     branches:
-    - main
+    - core24
 
 jobs:
   Refresh:
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ref:
-        - mir-libs-build
-        - core24
+        - mir-libs-build-core24
 
     steps:
     - name: Check out code

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -37,7 +37,6 @@ jobs:
         architecture: ${{ matrix.platform }}
         review-opts: --allow-classic
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
-        snapcraft-channel: edge
         launchpad-credentials: ${{ secrets.LAUNCHPAD_CREDENTIALS }}
         launchpad-accept-public-upload: true
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -31,10 +31,12 @@ jobs:
         sed -i 's@rev-list --count@rev-parse --short@' snap/snapcraft.yaml
 
     - name: Build and publish the snap
-      uses: canonical/actions/build-snap@multiarch
+      uses: canonical/actions/build-snap@release
       with:
         architecture: ${{ matrix.platform }}
         review-opts: --allow-classic
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
+        launchpad-credentials: ${{ secrets.LAUNCHPAD_CREDENTIALS }}
+        launchpad-accept-public-upload: true
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}
         publish-channel: edge/pr${{ github.event.number }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -18,6 +18,7 @@ jobs:
         - amd64
         - armhf
         - arm64
+      fail-fast: false
 
     steps:
     - name: Check out code

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -37,6 +37,7 @@ jobs:
         architecture: ${{ matrix.platform }}
         review-opts: --allow-classic
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
+        snapcraft-channel: edge
         launchpad-credentials: ${{ secrets.LAUNCHPAD_CREDENTIALS }}
         launchpad-accept-public-upload: true
         publish: ${{ github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ description: |
   environment that makes these “papercuts” visible and much more likely to be fixed.
 confinement: classic
 base: core24
+build-base: devel
 
 platforms:
   amd64:
@@ -52,7 +53,7 @@ parts:
       server_version=`git rev-list --count HEAD`
       mir_version=`LANG=C apt-cache policy mir-graphics-drivers-desktop | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
       craftctl set version=$server_version-mir$mir_version
-      if echo $mir_version | grep -e '+dev' -e '~rc' -q; then craftctl set grade=devel; else craftctl set grade=stable; fi
+      if echo $mir_version | grep -e '+dev' -e '~rc' -q; then craftctl set grade=devel; else craftctl set grade=devel; fi
     plugin: cmake
     source: .
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,9 +27,9 @@ apps:
     command: &_command usr/local/bin/miriway
     environment: &_environment
       # Prep for Mir
-      MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform
+      MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/mir/server-platform
       __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
-      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
       LIBINPUT_QUIRKS_DIR: ${SNAP}/usr/share/libinput
       PATH: ${SNAP}/bin/:${SNAP}/usr/bin/:${SNAP}/usr/local/bin/:${PATH}
       # For "reasons" this is being set despite this being a classic snap. This overwrites the nonsense
@@ -120,7 +120,7 @@ parts:
     - yambar
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
 
   mesa-no-patchelf:
     plugin: nil
@@ -130,4 +130,4 @@ parts:
       - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
     stage:
       # Only the libraries in .../dri need to not be patched, the rest come from the mesa part
-      - usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,10 +14,10 @@ confinement: classic
 base: core24
 build-base: devel
 
-platforms:
-  amd64:
-  arm64:
-  armhf:
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
 
 package-repositories:
   - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,10 +13,10 @@ description: |
 confinement: classic
 base: core24
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+platforms:
+  amd64:
+  arm64:
+  armhf:
 
 package-repositories:
   - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,58 +113,13 @@ parts:
     stage-packages:
     - libgl1-mesa-dri
     - libtinfo6
-    # included in this part because it tries to pull in mesa bits
-    - gvncviewer
+    # included in this part because they try to pull in mesa bits
     - swaybg
     - synapse
     - xwayland
+    - yambar
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
-
-  yambar:
-    build-attributes:
-      - enable-patchelf
-    plugin: meson
-    meson-parameters:
-      - -Dbackend-x11=disabled
-      - -Dbackend-wayland=enabled
-    build-packages:
-      - meson
-      - ninja-build
-      - wayland-protocols
-      - libasound2-dev
-      - libfcft-dev
-      - libfontconfig-dev
-      - libharfbuzz-dev
-      - libinotifytools0-dev
-      - libjson-c-dev
-      - libmpdclient-dev
-      - libpixman-1-dev
-      - libtllist-dev
-      - libudev-dev
-      - libwayland-dev
-      - libyaml-dev
-      - scdoc
-      - flex
-      - bison
-    source: https://codeberg.org/dnkl/yambar.git
-    source-tag: 1.9.0
-    source-depth: 1
-    stage-packages:
-      - fonts-font-awesome
-      - fonts-ubuntu
-      - libasound2
-      - libfcft4
-      - libjson-c5
-      - libmpdclient2
-      - libpixman-1-0
-      - libudev1
-      - libwayland-client0
-      - libwayland-cursor0
-      - libyaml-0-2
-    stage:
-      # The libraries in .../dri need no-patchelf, so they must come from the mesa-unpatched part
       - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
 
   mesa-no-patchelf:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
   It does, however, provide a way to test Mir and other components of a desktop 
   environment that makes these “papercuts” visible and much more likely to be fixed.
 confinement: classic
-base: core22
+base: core24
 
 architectures:
   - build-on: amd64
@@ -112,7 +112,7 @@ parts:
     plugin: nil
     stage-packages:
     - libgl1-mesa-dri
-    - libtinfo5
+    - libtinfo6
     # included in this part because it tries to pull in mesa bits
     - gvncviewer
     - swaybg


### PR DESCRIPTION
This is usable for testing

## Warning

Stuff needs evolving in the snap ecosystem before it can be promoted or merged.

1. `snapcraft` currently needs `build-base: devel` to support `core24`
2. the `core24` base snap dependency needs to be installed manually and from `edge`

## Only for the brave

```
snap install core24 --edge
snap install --classic --channel edge/pr88 miriway
```