### PR TITLE
feature: throttling shell component restart

### DIFF
--- a/miriway.cpp
+++ b/miriway.cpp
@@ -93,7 +93,7 @@ struct ShellComponents
         std::transform(begin(cmds), end(cmds), back_inserter(commands), ExternalClientLauncher::split_command);
     }
 
-    void launch_all()
+    void launch_all() const
     {
         for (auto const& command : commands)
         {
@@ -302,7 +302,7 @@ int main(int argc, char const* argv[])
             {
                 // The command is trying to restart too soon, so we throttle it. For every premature
                 // death that it has in a row, we increasingly throttle its restart time.
-                // After MAX_TOO_SHORT_RERUNS_IN_A_ROW is hit, we stop trying to rerun
+                // After max_too_short_reruns_in_a_row is hit, we stop trying to rerun
                 if (info->runs_in_quick_succession >= max_too_short_reruns_in_a_row)
                 {
                     mir::log_warning("No longer restarting app: %s", get_cmd_string(cmd).c_str());

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -286,13 +286,13 @@ int main(int argc, char const* argv[])
     std::function<void(std::vector<std::string> const&, std::shared_ptr<ShellComponentRunInfo>)> shell_launch
         = [&](std::vector<std::string> const& cmd, std::shared_ptr<ShellComponentRunInfo> info)
         {
-            static auto constexpr min_time_seconds_allowed_between_runs = 3;
-            static auto constexpr time_seconds_wait_foreach_run = 3;
-            static const int max_too_short_reruns_in_a_row = 10;
-            static const auto get_cmd_string = [](std::vector<std::string> const& cmd)
+            static int constexpr min_time_seconds_allowed_between_runs = 3;
+            static int constexpr time_seconds_wait_foreach_run = 3;
+            static int const max_too_short_reruns_in_a_row = 3;
+            static auto const get_cmd_string = [](std::vector<std::string> const& cmd)
             {
                 return std::accumulate(std::begin(cmd), std::end(cmd), std::string(),
-                    [](std::string current, std::string next)
+                    [](std::string const& current, std::string const& next)
                     {
                        return current.empty() ? next : current + " " + next;
                     });

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -239,19 +239,19 @@ public:
         {
             is_registered = true;
             auto const time_elapsed_since_last_run = now - it->last_run_time;
-            if (std::chrono::duration_cast<std::chrono::seconds>(time_elapsed_since_last_run) <= MIN_TIME_SECONDS_ALLOWED_BETWEEN_RUNS)
+            if (std::chrono::duration_cast<std::chrono::seconds>(time_elapsed_since_last_run) <= minTimeSecondsAllowedBetweenRuns)
             {
                 // The command is trying to restart too soon, so we throttle it. For every premature
                 // death that it has in a row, we increasingly throttle its restart time.
                 // After MAX_TOO_SHORT_RERUNS_IN_A_ROW is hit, we stop trying to rerun
-                if (it->num_runs_with_too_short_time_in_between >= MAX_TOO_SHORT_RERUNS_IN_A_ROW)
+                if (it->num_runs_with_too_short_time_in_between >= maxTooShortRerunsInARow)
                 {
                     prev_run_stats.erase(it);
                     mir::log_warning("No longer restarting app: %s", get_cmd_string(cmd).c_str());
                     return;
                 }
 
-                auto const time_to_wait = TIME_SECONDS_WAIT_FOREACH_RERUN * (it->num_runs_with_too_short_time_in_between + 1);
+                auto const time_to_wait = timeSecondsWaitForeachRun * (it->num_runs_with_too_short_time_in_between + 1);
                 auto const timer_fd = timerfd_create(CLOCK_REALTIME, 0);
                 if (timer_fd == -1)
                 {
@@ -299,9 +299,9 @@ public:
 
     std::function<void(std::vector<std::string> const&)> shell_launch;
 private:
-    static auto constexpr MIN_TIME_SECONDS_ALLOWED_BETWEEN_RUNS = 3s;
-    static auto constexpr TIME_SECONDS_WAIT_FOREACH_RERUN = 3s;
-    static const int MAX_TOO_SHORT_RERUNS_IN_A_ROW = 3;
+    static auto constexpr minTimeSecondsAllowedBetweenRuns = 3s;
+    static auto constexpr timeSecondsWaitForeachRun = 3s;
+    static const int maxTooShortRerunsInARow = 3;
 
     struct ShellComponentRunStats
     {


### PR DESCRIPTION
## What's new?
- If a shell component is dying ungracefully _and_ too quickly multiple times in a row, then we linearly throttle it to start later and later
- After 10 retries, we give up trying to keep it alive

**Question**: Can we set a timer in mir easily? I had to prepend to the event filter, which I don't like very much