### PR TITLE
feature: ability to specify a lockscreen app that gets run when the session is locked

### DIFF
--- a/miriway.cpp
+++ b/miriway.cpp
@@ -117,7 +117,7 @@ public:
     #if MIRAL_VERSION < MIR_VERSION_NUMBER(5, 0, 0)
                     mir::log_warning("SessionLockListener is not available before miral 5.0");
     #endif
-                    lockscreen_app = app.value();
+                    lockscreen_app = ExternalClientLauncher::split_command(app.value());
                 }
             },
       "lockscreen-app",
@@ -136,13 +136,13 @@ private:
     ConfigurationOption const lockscreen_option;
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 0, 0)
     SessionLockListener const session_locker{
-        [this]{ if (lockscreen_app) launch(ExternalClientLauncher::split_command(*lockscreen_app)); },
+        [this]{ if (lockscreen_app) launch(lockscreen_app.value()); },
         [] {}
     };
 #else
     static auto constexpr session_locker = [](mir::Server&){};
 #endif
-    std::optional<std::string> lockscreen_app;
+    std::optional<std::vector<std::string>> lockscreen_app;
 };
 
 // Build an index of commands from "<key>:<commands>" values and launch them by <key> (if found)

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -230,7 +230,7 @@ private:
 
     void reap()
     {
-        int status;
+        int status = 0;
         while (true)
         {
             auto const pid = waitpid(-1, &status, WNOHANG);
@@ -243,8 +243,9 @@ private:
 
                     if (auto it = shell_component_pids.find(pid); it != shell_component_pids.end())
                     {
-                        if (status)
+                        if (WIFEXITED(status) && WEXITSTATUS(status))
                         {
+                            mir::log_info("Process exited with status: %d", WEXITSTATUS(status));
                             on_reap = it->second;
                         }
                         shell_component_pids.erase(pid);

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -473,10 +473,12 @@ int main(int argc, char const* argv[])
 
                 return commands.input_event(e);
             }},
-            set_window_management_policy<WindowManagerPolicy>(commands),
-            lockscreen,
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 0, 0)
             SessionLockListener(
                 [&] { is_locked = true; },
-                [&] { is_locked = false; })
+                [&] { is_locked = false; }),
+#endif
+            set_window_management_policy<WindowManagerPolicy>(commands),
+            lockscreen
         });
 }


### PR DESCRIPTION
## How to test
1. Run Miriway with `./miriway --lockscreen-app=swaylock`
2. `loginctl lock-session <ID>`
3. Note that your session is locked
4. Enter your password in swaylock **or** `loginctl unlock-session <ID>` (**WARNING**: With `swaylock`, using `loginctl` to unlock will send you into a lockscreen-forever-loop, because Miriway sees swaylock exiting with status `2`, causing us to restart it over and over again. I have a pull request opened on that project to theoretically fix this)
5. Note that your session is unlocked

**WARNING**: This relies on this branch of Mir to work: https://github.com/canonical/mir/pull/3232