### PR TITLE
Use shell components from 24.04 archive

### DIFF
--- a/example-configs/miriway-config-LXQT.bash
+++ b/example-configs/miriway-config-LXQT.bash
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -e ~/.config ]; then mkdir ~/.config; fi
 
-shell_components="lxqt-policykit qterminal lxqt-runner lxqt-panel swaybg lubuntu-artwork"
+shell_components="lxqt-policykit qterminal lxqt-runner lxqt-panel lubuntu-artwork"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 
 for component in $shell_components
@@ -71,7 +71,7 @@ idle-timeout=600
 app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
 shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 
-shell-component=miriway-unsnap swaybg --mode fill --output '*' --image /usr/share/lubuntu/wallpapers/lubuntu-default-wallpaper.jpg
+shell-component=swaybg --mode fill --output '*' --image /usr/share/lubuntu/wallpapers/lubuntu-default-wallpaper.jpg
 shell-component=miriway-unsnap lxqt-policykit-agent
 shell-component=miriway-unsnap lxqt-panel
 ctrl-alt=t:miriway-unsnap qterminal

--- a/example-configs/miriway-config-MATE.bash
+++ b/example-configs/miriway-config-MATE.bash
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -e ~/.config ]; then mkdir ~/.config; fi
 
-shell_components="mate-panel mate-terminal swaybg /usr/libexec/mate-notification-daemon/mate-notification-daemon"
+shell_components="mate-panel mate-terminal /usr/libexec/mate-notification-daemon/mate-notification-daemon"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 
 for component in $shell_components

--- a/example-configs/miriway-config-SWAY.bash
+++ b/example-configs/miriway-config-SWAY.bash
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -e ~/.config ]; then mkdir ~/.config; fi
 
-shell_components="swaybg waybar wofi swaync kgx swaylock"
+shell_components="waybar wofi kgx"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 waybar_config="${XDG_CONFIG_HOME:-$HOME/.config}/waybar/config"
 waybar_style="${XDG_CONFIG_HOME:-$HOME/.config}/waybar/style.css"
@@ -97,14 +97,18 @@ idle-timeout=600
 app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
 shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 ctrl-alt=t:miriway-unsnap kgx
-shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice swaync
+shell-component=systemd-run --user --scope --slice=background.slice swaybg --mode fill --output '*' --image ${background}
+shell-component=systemd-run --user --scope --slice=background.slice swaync
 
-shell-component=miriway-unsnap swaybg --mode fill --output '*' --image '${background}'
 shell-component=miriway-unsnap waybar
 shell-meta=a:miriway-unsnap wofi --show drun --location top_left
 
-shell-add-wayland-extension=ext_session_lock_manager_v1
-shell-meta=l:miriway-unsnap swaylock
+$(if find $(dirname "$0")/../usr/lib -name libmirserver.so.59 | grep libmirserver.so.59 > /dev/null; then
+  echo shell-ctrl-alt=l:swaylock -i ${background}
+else
+  echo shell-ctrl-alt=l:miriway-unsnap loginctl lock-session
+  echo lockscreen-app=swaylock -i ${background}
+fi)
 
 meta=Left:@dock-left
 meta=Right:@dock-right

--- a/example-configs/miriway-config-XFCE.bash
+++ b/example-configs/miriway-config-XFCE.bash
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -e ~/.config ]; then mkdir ~/.config; fi
 
-shell_components="swaybg xfce4-terminal xfce4-appfinder"
+shell_components="xfce4-terminal xfce4-appfinder"
 miriway_config="${XDG_CONFIG_HOME:-$HOME/.config}/miriway-shell.config"
 
 for component in $shell_components
@@ -82,7 +82,7 @@ idle-timeout=600
 app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
 shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 
-shell-component=miriway-unsnap swaybg --mode fill --output '*' --image '${background}'
+shell-component=swaybg --mode fill --output '*' --image '${background}'
 shell-meta=a:miriway-unsnap xfce4-appfinder --disable-server
 ctrl-alt=t:miriway-unsnap xfce4-terminal
 

--- a/example-configs/miriway-config-alan_g.bash
+++ b/example-configs/miriway-config-alan_g.bash
@@ -78,6 +78,7 @@ fi
 
 mkdir "$(dirname "${yambar_config}")" -p -m 700
 
+miriway_display="${miriway_config/%config/display}"
 if  [ -e "/usr/share/backgrounds/warty-final-ubuntu.png" ]; then
   # fall back to Ubuntu default
   background="/usr/share/backgrounds/warty-final-ubuntu.png"
@@ -102,8 +103,16 @@ ctrl-alt=t:miriway-unsnap kgx
 shell-meta=a:miriway-unsnap synapse
 meta=Print:miriway-unsnap sh -c "grim ~/Pictures/screenshot-\$(date --iso-8601=seconds).png"
 
-shell-ctrl-alt=l:miriway-unsnap loginctl lock-session
-lockscreen-app=miriway-unsnap swaylock -i /usr/share/backgrounds/warty-final-ubuntu.png
+$(if find $(dirname "$0")/../usr/lib -name libmirserver.so.59 | grep libmirserver.so.59 > /dev/null; then
+  echo shell-ctrl-alt=l:swaylock -i ${background}
+else
+  echo shell-ctrl-alt=l:miriway-unsnap loginctl lock-session
+  echo lockscreen-app=swaylock -i ${background}
+fi)
+
+ctrl-alt=d:cp ${miriway_display}~docked ${miriway_display}
+ctrl-alt=u:cp ${miriway_display}~undocked ${miriway_display}
+ctrl-alt=s:miriway-swap
 
 meta=Left:@dock-left
 meta=Right:@dock-right
@@ -114,7 +123,7 @@ meta=Page_Up:@workspace-up
 meta=Page_Down:@workspace-down
 ctrl-alt=BackSpace:@exit
 
-display-config=static=${miriway_config/%config/display}
+display-config=static=${miriway_display}
 EOT
 
 # Ensure we have a config file with the fixed options
@@ -129,15 +138,31 @@ bar:
   font: *ubuntu
 
   left:
-    - label:
+    - cpu:
         content:
-          string:
-            text: " start"
-            margin: 5
-            on-click: miriway-unsnap synapse
+          map:
             deco: &greybg
               background:
                 color: 3f3f3fff
+            conditions:
+              id >= 0:
+                - ramp:
+                    tag: cpu
+                    items:
+                      - string: {text: ▁, foreground: 00ff00ff}
+                      - string: {text: ▂, foreground: 00ff00ff}
+                      - string: {text: ▃, foreground: 00ff00ff}
+                      - string: {text: ▄}
+                      - string: {text: ▅}
+                      - string: {text: ▆, foreground: ffa600ff}
+                      - string: {text: ▇, foreground: ffa600ff}
+                      - string: {text: █, foreground: ff0000ff}
+    - mem:
+        content:
+          - string:
+              margin: 5
+              text: "mem: {percent_used}%"
+              deco: *greybg
 
   center:
     - clock:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,9 @@ parts:
     - libgl1-mesa-dri
     - libtinfo6
     # included in this part because they try to pull in mesa bits
+    - sway-notification-center
     - swaybg
+    - swaylock
     - synapse
     - xwayland
     - yambar

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,12 +11,12 @@ description: |
   It does, however, provide a way to test Mir and other components of a desktop 
   environment that makes these “papercuts” visible and much more likely to be fixed.
 confinement: classic
-base: core22
+base: core24
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+platforms:
+  amd64:
+  arm64:
+  armhf:
 
 package-repositories:
   - type: apt
@@ -64,6 +64,7 @@ parts:
       - libxkbcommon-dev
       - g++
       - make
+      - git
     stage-packages:
       # Stage libmiral<n> indirectly as we cannot (since core22) do `try:/else:`
       - libmiral-dev
@@ -112,7 +113,7 @@ parts:
     plugin: nil
     stage-packages:
     - libgl1-mesa-dri
-    - libtinfo5
+    - libtinfo6
     # included in this part because it tries to pull in mesa bits
     - gvncviewer
     - swaybg

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -114,59 +114,14 @@ parts:
     stage-packages:
     - libgl1-mesa-dri
     - libtinfo6
-    # included in this part because it tries to pull in mesa bits
-    - gvncviewer
+    # included in this part because they try to pull in mesa bits
     - swaybg
     - synapse
     - xwayland
+    - yambar
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
-
-  yambar:
-    build-attributes:
-      - enable-patchelf
-    plugin: meson
-    meson-parameters:
-      - -Dbackend-x11=disabled
-      - -Dbackend-wayland=enabled
-    build-packages:
-      - meson
-      - ninja-build
-      - wayland-protocols
-      - libasound2-dev
-      - libfcft-dev
-      - libfontconfig-dev
-      - libharfbuzz-dev
-      - libinotifytools0-dev
-      - libjson-c-dev
-      - libmpdclient-dev
-      - libpixman-1-dev
-      - libtllist-dev
-      - libudev-dev
-      - libwayland-dev
-      - libyaml-dev
-      - scdoc
-      - flex
-      - bison
-    source: https://codeberg.org/dnkl/yambar.git
-    source-tag: 1.9.0
-    source-depth: 1
-    stage-packages:
-      - fonts-font-awesome
-      - fonts-ubuntu
-      - libasound2
-      - libfcft4
-      - libjson-c5
-      - libmpdclient2
-      - libpixman-1-0
-      - libudev1
-      - libwayland-client0
-      - libwayland-cursor0
-      - libyaml-0-2
-    stage:
-      # The libraries in .../dri need no-patchelf, so they must come from the mesa-unpatched part
-      - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
 
   mesa-no-patchelf:
     plugin: nil


### PR DESCRIPTION
We can use shell components from the 24.04 archive that were not there from 22.04