### PR TITLE
Add option to install Miriway SDDM configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ include(GNUInstallDirs)
 include(FindPkgConfig)
 include(CheckIncludeFileCXX)
 
+option(SDDM "Install configuration for SDDM?" OFF)
+
 pkg_check_modules(MIRAL miral>=5.1 REQUIRED)
 pkg_check_modules(XKBCOMMON xkbcommon REQUIRED)
 
@@ -88,3 +90,10 @@ install(FILES ${CMAKE_SOURCE_DIR}/miriway-shell.config
     DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/xdg-miriway
 )
 
+if(SDDM)
+    configure_file(${CMAKE_SOURCE_DIR}/sddm/miriway.conf.in
+        ${CMAKE_BINARY_DIR}/sddm/miriway.conf @ONLY)
+    install(FILES ${CMAKE_BINARY_DIR}/sddm/miriway.conf
+        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/sddm.conf.d/
+    )
+endif()

--- a/sddm/miriway.conf.in
+++ b/sddm/miriway.conf.in
@@ -1,0 +1,7 @@
+[General]
+DisplayServer=wayland
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+InputMethod=
+
+[Wayland]
+CompositorCommand=@CMAKE_INSTALL_FULL_BINDIR@/miriway --add-wayland-extensions=zwlr_layer_shell_v1


### PR DESCRIPTION
This allows users to configure SDDM to use Miriway as a compositor, enabling a consistent experience from login into the desktop.