### PR TITLE
Install miriway-session.target without executable bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/systemd/usr/libexec/miriway-session-shutdow
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
 )
 
-install(PROGRAMS ${CMAKE_SOURCE_DIR}/systemd/usr/lib/systemd/user/miriway-session.target
+install(FILES ${CMAKE_SOURCE_DIR}/systemd/usr/lib/systemd/user/miriway-session.target
     DESTINATION /usr/lib/systemd/user/
 )
 if(SDDM)


### PR DESCRIPTION
To stop the following warning from systemd:

```
machine # [   13.123163] systemd[906]: Configuration file /run/current-system/sw/share/systemd/user/miriway-session.target is marked executable. Please remove executable permission bits. Proceeding anyway.
```