### PR TITLE
Activate the workspace for raised windows

### DIFF
--- a/miriway_workspace_manager.cpp
+++ b/miriway_workspace_manager.cpp
@@ -217,6 +217,15 @@ void miriway::WorkspaceManager::change_active_workspace(
     }
 }
 
+void miriway::WorkspaceManager::activate_workspace_containing(Window const& window)
+{
+    tools_.for_each_workspace_containing(window,
+        [this](std::shared_ptr<Workspace> const& workspace)
+        {
+            change_active_workspace(workspace, active_workspace(), Window{});
+        });
+}
+
 void miriway::WorkspaceManager::advise_adding_to_workspace(std::shared_ptr<Workspace> const& workspace,
                                                            std::vector<Window> const& windows)
 {

--- a/miriway_workspace_manager.h
+++ b/miriway_workspace_manager.h
@@ -54,6 +54,7 @@ public:
                                  std::shared_ptr<Workspace> const& old_active,
                                  miral::Window const& window);
 
+    void activate_workspace_containing(Window const& window);
 
     void advise_new_window(const WindowInfo &window_info);
 
@@ -126,6 +127,15 @@ protected:
         }
 
         WMStrategy::handle_modify_window(window_info, mods);
+    }
+
+    void handle_raise_window(WindowInfo& window_info) override
+    {
+        if (in_hidden_workspace(window_info))
+        {
+            activate_workspace_containing(window_info.window());
+        }
+        WMStrategy::handle_raise_window(window_info);
     }
 };
 } // miriway


### PR DESCRIPTION
With the implementation of xdg_activation_v1 in Mir 2.19 we can get "raise" requests from windows on hidden workspaces. We should switch workspace before giving these windows focus