### PR TITLE
Update to work with Mesa-24.2

### DIFF
--- a/miriway-unsnap
+++ b/miriway-unsnap
@@ -4,6 +4,8 @@ if [ "$SNAP_NAME" == "miriway" ]; then
   unset __EGL_VENDOR_LIBRARY_DIRS
   unset LIBGL_DRIVERS_PATH
   unset LIBINPUT_QUIRKS_DIR
+  unset DRIRC_CONFIGDIR
+  unset XDG_DESKTOP_PORTAL_DIR
 
   PATH="$(echo "$PATH" | sed "s#$SNAP[^:]*:##g")"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,6 +128,7 @@ parts:
       - -usr/include
       - -usr/lib/*/pkgconfig
       - -usr/lib/*/libmir*.so
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
 
   example-configs:
     plugin: dump
@@ -168,6 +169,7 @@ parts:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
       - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri/libdril_dri.so
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
 
   mesa-no-patchelf:
     plugin: nil
@@ -179,6 +181,7 @@ parts:
       # Only the libraries in .../dri need to not be patched, the rest come from the mesa part
       - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri/libdril_dri.so
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
 
   xdg-desktop-portal-wlr:
     plugin: meson

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,8 +52,7 @@ apps:
       # environment variable is only intended to be used in their testing environment
       # but we are abusing it for our purposes here.
       XDG_DESKTOP_PORTAL_DIR: $SNAP/usr/share/xdg-desktop-portal/portals/
-      # For "reasons" this is being set despite this being a classic snap. This overwrites the nonsense
-      LD_LIBRARY_PATH: ""
+      DRIRC_CONFIGDIR: ${SNAP}/usr/share/drirc.d
 
   session:
     command-chain: *command_chain
@@ -155,6 +154,9 @@ parts:
     stage-packages:
     - libgl1-mesa-dri
     - libtinfo6
+    - libdrm2
+    - libdrm-common
+    - libgbm1
     # included in this part because they try to pull in mesa bits
     - sway-notification-center
     - swaybg
@@ -165,6 +167,7 @@ parts:
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri/libdril_dri.so
 
   mesa-no-patchelf:
     plugin: nil
@@ -175,11 +178,14 @@ parts:
     stage:
       # Only the libraries in .../dri need to not be patched, the rest come from the mesa part
       - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri/libdril_dri.so
 
   xdg-desktop-portal-wlr:
     plugin: meson
     source: https://github.com/emersion/xdg-desktop-portal-wlr.git
     source-tag: v0.5.0
+    build-attributes:
+      - enable-patchelf
     build-packages:
       - meson
       - ninja-build
@@ -190,3 +196,6 @@ parts:
       - wayland-protocols
     stage-packages:
       - slurp
+      - libinih1
+      - libwayland-cursor0
+      - libcairo2


### PR DESCRIPTION
This is the old issue of patchelf dropping the build-id, but this time it is the (internal to Mesa drivers) libgallium library that's SEGFAULTing when checking the build-id

Fixes: #145