### PR TITLE
track active workspace better

### DIFF
--- a/miriway_ext_workspace_v1.cpp
+++ b/miriway_ext_workspace_v1.cpp
@@ -313,6 +313,7 @@ void miriway::ExtWorkspaceManagerV1::workspace_deactivated(std::shared_ptr<Works
 
 void miriway::ExtWorkspaceManagerV1::workspace_destroyed(std::shared_ptr<Workspace> const& wksp)
 {
+    auto searching = true;
     unsigned int i = 0;
     for (auto it = workspaces.begin(); it != workspaces.end();)
     {
@@ -321,11 +322,15 @@ void miriway::ExtWorkspaceManagerV1::workspace_destroyed(std::shared_ptr<Workspa
             the_workspace_group->send_workspace_leave_event(it->second->resource);
             it->second->send_removed_event();
             it = workspaces.erase(it);
+            searching = false;
         }
         else
         {
             ++i;
-            update_workspace_info(it->second, i);
+            if (!searching)
+            {
+                update_workspace_info(it->second, i);
+            }
             ++it;
         }
     }

--- a/miriway_ext_workspace_v1.h
+++ b/miriway_ext_workspace_v1.h
@@ -29,12 +29,12 @@ namespace miriway
 class ExtWorkspaceV1 : public WorkspaceHooks
 {
 public:
-    void on_workspace_create(const std::shared_ptr<Workspace> &wksp) override;
-    void on_workspace_activate(const std::shared_ptr<Workspace> &wksp) override;
-    void on_workspace_deactivate(const std::shared_ptr<Workspace> &wksp) override;
-    void on_workspace_destroy(const std::shared_ptr<Workspace> &wksp) override;
-    void on_output_create(const Output& output) override;
-    void on_output_destroy(const Output& output) override;
+    void on_workspace_create(std::shared_ptr<Workspace> const& wksp) override;
+    void on_workspace_activate(std::shared_ptr<Workspace> const& wksp) override;
+    void on_workspace_deactivate(std::shared_ptr<Workspace> const& wksp) override;
+    void on_workspace_destroy(std::shared_ptr<Workspace> const& wksp) override;
+    void on_output_create(Output const& output) override;
+    void on_output_destroy(Output const& output) override;
     void set_workspace_activator_callback(std::function<void(std::shared_ptr<Workspace> const& wksp)> f) override;
 };
 

--- a/miriway_workspace_manager.cpp
+++ b/miriway_workspace_manager.cpp
@@ -128,6 +128,7 @@ void miriway::WorkspaceManager::append_new_workspace()
     workspaces.push_back(tools_.create_workspace());
     active_workspace_ = --workspaces.cend();
     hooks.on_workspace_create(*active_workspace_);
+    hooks.on_workspace_activate(*active_workspace_);
 }
 
 void miriway::WorkspaceManager::erase_if_empty(workspace_list::const_iterator const& old_workspace)


### PR DESCRIPTION
We were holding enough information to inform a new client (or a restarting one) of the active workspace