### PR TITLE
Add xkbcommon to target_include_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(miriwaycommon STATIC
         miriway_documenting_store.h
 )
 
-target_include_directories(miriwaycommon PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS} ${MIRWAYLAND_INCLUDE_DIRS})
+target_include_directories(miriwaycommon PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS} ${MIRWAYLAND_INCLUDE_DIRS} ${XKBCOMMON_INCLUDE_DIRS})
 target_link_libraries(     miriwaycommon PUBLIC        ${MIRAL_LDFLAGS} ${MIRWAYLAND_LDFLAGS} ${XKBCOMMON_LIBRARIES})
 target_compile_definitions(miriwaycommon PRIVATE MIR_LOG_COMPONENT="miriway")
 
@@ -50,7 +50,7 @@ add_executable(miriway-run-shell
     miriway-run-shell.cpp
 )
 target_link_libraries(miriway-run-shell ${MIRAL_LDFLAGS})
-target_include_directories(miriway-run-shell PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS})
+target_include_directories(miriway-run-shell PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS} ${XKBCOMMON_INCLUDE_DIRS})
 target_compile_definitions(miriway-run-shell PRIVATE MIR_LOG_COMPONENT="miriway")
 
 add_custom_target(miriway ALL


### PR DESCRIPTION
Allows the xkbcommon includes to be found by pkgconfig on distributions that do non-standard things with their includes