### PR TITLE
add functionality to bind unmodified keys

### DIFF
--- a/example-configs/miriway-config-LXQt.bash
+++ b/example-configs/miriway-config-LXQt.bash
@@ -58,9 +58,9 @@ shell-component=miriway-unsnap lxqt-policykit-agent
 shell-component=miriway-unsnap lxqt-panel
 ctrl-alt=t:miriway-unsnap qterminal
 shell-meta=a:miriway-unsnap lxqt-runner
-shell-plain=F12:qterminal -d
-plain=XF86MonBrightnessUp:lxqt-config-brightness -i
-plain=XF86MonBrightnessDown:lxqt-config-brightness -d
+shell-plain=F12:miriway-unsnap qterminal -d
+plain=XF86MonBrightnessUp:miriway-unsnap lxqt-config-brightness -i
+plain=XF86MonBrightnessDown:miriway-unsnap lxqt-config-brightness -d
 
 meta=Left:@dock-left
 meta=Right:@dock-right

--- a/example-configs/miriway-config-LXQt.bash
+++ b/example-configs/miriway-config-LXQt.bash
@@ -58,6 +58,9 @@ shell-component=miriway-unsnap lxqt-policykit-agent
 shell-component=miriway-unsnap lxqt-panel
 ctrl-alt=t:miriway-unsnap qterminal
 shell-meta=a:miriway-unsnap lxqt-runner
+shell-key=F12:qterminal -d
+bare-key=XF86MonBrightnessUp:lxqt-config-brightness -i
+bare-key=XF86MonBrightnessDown:lxqt-config-brightness -d
 
 meta=Left:@dock-left
 meta=Right:@dock-right

--- a/example-configs/miriway-config-LXQt.bash
+++ b/example-configs/miriway-config-LXQt.bash
@@ -58,9 +58,9 @@ shell-component=miriway-unsnap lxqt-policykit-agent
 shell-component=miriway-unsnap lxqt-panel
 ctrl-alt=t:miriway-unsnap qterminal
 shell-meta=a:miriway-unsnap lxqt-runner
-shell-key=F12:qterminal -d
-bare-key=XF86MonBrightnessUp:lxqt-config-brightness -i
-bare-key=XF86MonBrightnessDown:lxqt-config-brightness -d
+shell-plain=F12:qterminal -d
+plain=XF86MonBrightnessUp:lxqt-config-brightness -i
+plain=XF86MonBrightnessDown:lxqt-config-brightness -d
 
 meta=Left:@dock-left
 meta=Right:@dock-right

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -245,6 +245,8 @@ void migrate_config_to_settings(std::filesystem::path const& config_file_path,
         {"meta",                                    "command_meta"},
         {"ctrl-alt",                                "command_ctrl_alt"},
         {"alt",                                     "command_alt"},
+        {"shell-key",                               "command_shell_plain"},
+        {"bare-key",                                "command_plain"},
         {"cursor-scale",                            "cursor_scale"},
         {"keymap",                                  "keymap"},
         {"key-repeat-rate",                         "keyboard_repeat_rate"},
@@ -510,6 +512,18 @@ int main(int argc, char const* argv[])
         "alt <key>:<command> shortcut (may be specified multiple times)",
         [&](auto cmd) { child_control.run_app(cmd); }};
 
+    CommandIndex shell_key{
+        *settings_store,
+        "shell-plain",
+        "unmodified <key>:<command> shortcut with shell privileges (may be specified multiple times)",
+        [&child_control](auto cmd) { child_control.run_shell(cmd); }};
+
+    CommandIndex bare_key{
+        *settings_store,
+        "plain",
+        "unmodified <key>:<command> shortcut (may be specified multiple times)",
+        [&](auto cmd) { child_control.run_app(cmd); }};
+
     Keymap keymap = getenv("MIRIWAY_SYSTEM_LOCALE1_KEYMAP") ? Keymap::system_locale1() : Keymap{*settings_store};
     settings_store.reset();
 
@@ -527,7 +541,8 @@ int main(int argc, char const* argv[])
         runner,
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_meta.try_command_for(c, s, cmd) || meta.try_command_for(c, s, cmd); },
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_ctrl_alt.try_command_for(c, s, cmd) || ctrl_alt.try_command_for(c, s, cmd); },
-        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_alt.try_command_for(c, s, cmd) || alt.try_command_for(c, s, cmd); }};
+        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_alt.try_command_for(c, s, cmd) || alt.try_command_for(c, s, cmd); },
+        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_key.try_command_for(c, s, cmd) || bare_key.try_command_for(c, s, cmd); }};
 
     std::atomic<bool> is_locked = false;
     LockScreen lockscreen(

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -186,7 +186,7 @@ public:
 
     bool try_command_for(xkb_keysym_t key_code, bool with_shift, ShellCommands* cmd) const
     {
-        auto const i = commands.find(std::tolower(key_code));
+        auto const i = commands.find(xkb_keysym_to_lower(key_code));
         bool const found = i != end(commands);
         if (found) i->second(cmd, with_shift);
         return found;
@@ -245,8 +245,8 @@ void migrate_config_to_settings(std::filesystem::path const& config_file_path,
         {"meta",                                    "command_meta"},
         {"ctrl-alt",                                "command_ctrl_alt"},
         {"alt",                                     "command_alt"},
-        {"shell-plain",                               "command_shell_plain"},
-        {"plain",                                    "command_plain"},
+        {"shell-plain",                             "command_shell_plain"},
+        {"plain",                                   "command_plain"},
         {"cursor-scale",                            "cursor_scale"},
         {"keymap",                                  "keymap"},
         {"key-repeat-rate",                         "keyboard_repeat_rate"},
@@ -518,7 +518,7 @@ int main(int argc, char const* argv[])
         "unmodified <key>:<command> shortcut with shell privileges (may be specified multiple times)",
         [&child_control](auto cmd) { child_control.run_shell(cmd); }};
 
-    CommandIndex plain_key{
+    CommandIndex plain{
         *settings_store,
         "plain",
         "unmodified <key>:<command> shortcut (may be specified multiple times)",
@@ -542,7 +542,7 @@ int main(int argc, char const* argv[])
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_meta.try_command_for(c, s, cmd) || meta.try_command_for(c, s, cmd); },
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_ctrl_alt.try_command_for(c, s, cmd) || ctrl_alt.try_command_for(c, s, cmd); },
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_alt.try_command_for(c, s, cmd) || alt.try_command_for(c, s, cmd); },
-        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_plain.try_command_for(c, s, cmd) || plain_key.try_command_for(c, s, cmd); }};
+        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_plain.try_command_for(c, s, cmd) || plain.try_command_for(c, s, cmd); }};
 
     std::atomic<bool> is_locked = false;
     LockScreen lockscreen(

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -245,8 +245,8 @@ void migrate_config_to_settings(std::filesystem::path const& config_file_path,
         {"meta",                                    "command_meta"},
         {"ctrl-alt",                                "command_ctrl_alt"},
         {"alt",                                     "command_alt"},
-        {"shell-key",                               "command_shell_plain"},
-        {"bare-key",                                "command_plain"},
+        {"shell-plain",                               "command_shell_plain"},
+        {"plain",                                    "command_plain"},
         {"cursor-scale",                            "cursor_scale"},
         {"keymap",                                  "keymap"},
         {"key-repeat-rate",                         "keyboard_repeat_rate"},
@@ -512,13 +512,13 @@ int main(int argc, char const* argv[])
         "alt <key>:<command> shortcut (may be specified multiple times)",
         [&](auto cmd) { child_control.run_app(cmd); }};
 
-    CommandIndex shell_key{
+    CommandIndex shell_plain{
         *settings_store,
         "shell-plain",
         "unmodified <key>:<command> shortcut with shell privileges (may be specified multiple times)",
         [&child_control](auto cmd) { child_control.run_shell(cmd); }};
 
-    CommandIndex bare_key{
+    CommandIndex plain_key{
         *settings_store,
         "plain",
         "unmodified <key>:<command> shortcut (may be specified multiple times)",
@@ -542,7 +542,7 @@ int main(int argc, char const* argv[])
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_meta.try_command_for(c, s, cmd) || meta.try_command_for(c, s, cmd); },
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_ctrl_alt.try_command_for(c, s, cmd) || ctrl_alt.try_command_for(c, s, cmd); },
         [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_alt.try_command_for(c, s, cmd) || alt.try_command_for(c, s, cmd); },
-        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_key.try_command_for(c, s, cmd) || bare_key.try_command_for(c, s, cmd); }};
+        [&] (xkb_keysym_t c, bool s, ShellCommands* cmd) { return shell_plain.try_command_for(c, s, cmd) || plain_key.try_command_for(c, s, cmd); }};
 
     std::atomic<bool> is_locked = false;
     LockScreen lockscreen(

--- a/miriway_commands.cpp
+++ b/miriway_commands.cpp
@@ -27,8 +27,8 @@
 #include <mir/log.h>
 
 miriway::ShellCommands::ShellCommands(
-    MirRunner& runner, CommandFunctor meta_command, CommandFunctor ctrl_alt_command, CommandFunctor alt_command) :
-    runner{runner}, meta_command{std::move(meta_command)}, ctrl_alt_command{std::move(ctrl_alt_command)}, alt_command{std::move(alt_command)}
+    MirRunner& runner, CommandFunctor meta_command, CommandFunctor ctrl_alt_command, CommandFunctor alt_command, CommandFunctor key_command) :
+    runner{runner}, meta_command{std::move(meta_command)}, ctrl_alt_command{std::move(ctrl_alt_command)}, alt_command{std::move(alt_command)}, key_command{std::move(key_command)}
 {
 }
 
@@ -84,6 +84,16 @@ auto miriway::ShellCommands::keyboard_shortcuts(MirKeyboardEvent const* kev) -> 
         if ((mods & mir_input_event_modifier_alt) == mir_input_event_modifier_alt)
         {
             return alt_command(key_code, mods & mir_input_event_modifier_shift, this);
+        }
+
+        auto const real_mods =
+            mir_input_event_modifier_alt |
+            mir_input_event_modifier_shift |
+            mir_input_event_modifier_ctrl |
+            mir_input_event_modifier_meta;
+        if (!(mods & real_mods))
+        {
+            return key_command(key_code, false, this);
         }
     }
 

--- a/miriway_commands.h
+++ b/miriway_commands.h
@@ -43,7 +43,7 @@ class ShellCommands
 public:
     using CommandFunctor = std::function<bool(xkb_keysym_t key_code, bool with_shift, ShellCommands* cmd)>;
 
-    ShellCommands(MirRunner& runner, CommandFunctor meta_command, CommandFunctor ctrl_alt_command, CommandFunctor alt_command);
+    ShellCommands(MirRunner& runner, CommandFunctor meta_command, CommandFunctor ctrl_alt_command, CommandFunctor alt_command, CommandFunctor key_command);
 
     void init_window_manager(WindowManagerPolicy* wm);
 
@@ -74,6 +74,7 @@ private:
     CommandFunctor meta_command;
     CommandFunctor ctrl_alt_command;
     CommandFunctor alt_command;
+    CommandFunctor key_command;
     WindowManagerPolicy* wm = nullptr;
     std::atomic<bool> shell_commands_active = true;
 

--- a/miriway_commands.h
+++ b/miriway_commands.h
@@ -37,7 +37,7 @@ using namespace miral;
 class WindowManagerPolicy;
 
 // Process `input_event()` to identify commands Miriway needs to handle.
-// Commands will be routed to MirRunner, the WindowManagerPolicy, meta_command or ctrl_alt_command as appropriate
+// Commands will be routed to MirRunner, the WindowManagerPolicy, or a CommandFunctor as appropriate
 class ShellCommands
 {
 public:


### PR DESCRIPTION
- Extend ShellCommands constructor to accept a 4th CommandFunctor key_command
- Add key_command member to private section
- Update constructor to include key_command
- Add branch at end of mir_keyboard_action_down block, strips lock modifiers from the mask, and if no real modifiers remain, dispatches to key_command
- Add 2 new CommandIndex instances
  * shell_plain (shell privileges)
  * plain (normal app)
- Pass 4th lambda into ShellCommands to try both
- Register both in runner.run_with()
- Add examples to miriway-config-LXQt.bash

When using Miriway in conjunction with LXQt, on real hardware, the lack of ability to bind bare keys like the XF86 keys to adjust things like volume and brightness is a problem, due to LXQt not providing any mechanism itself to map keys, instead relying on the wayland compositor to take care of it.   I've tested this on both Fedora and openSUSE on a couple of thinkpads over the last couple days, and I haven't found any problems or seen any regressions, but I'll certainly admit that  I may have missed something.