### PR TITLE
Fix alphabetic key shortcuts after live_config migration

### DIFF
--- a/miriway.cpp
+++ b/miriway.cpp
@@ -205,7 +205,8 @@ private:
             {
                 if (command[split+1] != '@')
                 {
-                    commands[to_key(command.substr(0, split))] =
+                    auto const k = to_key(command.substr(0, split));
+                    commands[xkb_keysym_to_lower(k)] =
                         [this, argv = ExternalClientLauncher::split_command(command.substr(split+1))](miriway::ShellCommands*, bool)
                         {
                             launch(argv);
@@ -215,7 +216,7 @@ private:
                 {
                     if (auto const lookup = wm_command.find(command.substr(split+2)); lookup != std::end(wm_command))
                     {
-                        commands[to_key(command.substr(0, split))] = lookup->second;
+                        commands[xkb_keysym_to_lower(to_key(command.substr(0, split)))] = lookup->second;
                     }
                 }
             }

--- a/miriway.cpp
+++ b/miriway.cpp
@@ -203,10 +203,11 @@ private:
         {
             if (auto const split = command.find(':'); split >= 1 && split+1 < command.size())
             {
+                auto const key = xkb_keysym_to_lower(to_key(command.substr(0, split)));
+
                 if (command[split+1] != '@')
                 {
-                    auto const k = to_key(command.substr(0, split));
-                    commands[xkb_keysym_to_lower(k)] =
+                    commands[key] =
                         [this, argv = ExternalClientLauncher::split_command(command.substr(split+1))](miriway::ShellCommands*, bool)
                         {
                             launch(argv);
@@ -216,7 +217,7 @@ private:
                 {
                     if (auto const lookup = wm_command.find(command.substr(split+2)); lookup != std::end(wm_command))
                     {
-                        commands[xkb_keysym_to_lower(to_key(command.substr(0, split)))] = lookup->second;
+                        commands[key] = lookup->second;
                     }
                 }
             }


### PR DESCRIPTION
Fix alphabetic key shortcuts after live_config migration

The recent settings migration moved `command_*` options to `.settings` via live_config. This exposed a keysym case mismatch: `to_key("T")` stored `XKB_KEY_T` while the event path looked up the lowercased version, so letter-based shortcuts (Meta+P, Ctrl+Alt+T, etc.) were silently ignored.

Normalize keysyms at storage time in `CommandIndex::populate`. `command_meta` / `command_ctrl_alt` / `command_shell_*` bindings now work correctly, including under `MIRIWAY_CONFIG_DIR=lxqt`.

Tested with Ctrl+Alt+T, Meta+P, Ctrl+Alt+Up (@toggle-always-on-top) and several others on Lubuntu Stonking with Miriway and Mir both at the tip of main, in QEMU.