### PR TITLE
snap: make it parallel installable

### DIFF
--- a/miriway
+++ b/miriway
@@ -29,14 +29,14 @@ then
   exit 1
 fi
 
-if [ -e "/etc/xdg/xdg-miriway" ] && [ "${XDG_CONFIG_DIRS#*/etc/xdg/xdg-miriway}" = "${XDG_CONFIG_DIRS}" ]
+if [ -e "/etc/xdg/xdg-${MIRIWAY_XDG:=miriway}" ] && [ "${XDG_CONFIG_DIRS#*/etc/xdg/xdg-$MIRIWAY_XDG}" = "${XDG_CONFIG_DIRS}" ]
 then
-  export XDG_CONFIG_DIRS="/etc/xdg/xdg-miriway:${XDG_CONFIG_DIRS:-/etc/xdg}"
+  export XDG_CONFIG_DIRS="/etc/xdg/xdg-${MIRIWAY_XDG}:${XDG_CONFIG_DIRS:-/etc/xdg}"
 fi
 
-if [ -e "/usr/local/etc/xdg/xdg-miriway" ] && [ "${XDG_CONFIG_DIRS#*/usr/local/etc/xdg/xdg-miriway}" = "${XDG_CONFIG_DIRS}" ]
+if [ -e "/usr/local/etc/xdg/xdg-${MIRIWAY_XDG}" ] && [ "${XDG_CONFIG_DIRS#*/usr/local/etc/xdg/xdg-$MIRIWAY_XDG}" = "${XDG_CONFIG_DIRS}" ]
 then
-  export XDG_CONFIG_DIRS="/usr/local/etc/xdg/xdg-miriway:${XDG_CONFIG_DIRS:-/etc/xdg}"
+  export XDG_CONFIG_DIRS="/usr/local/etc/xdg/xdg-${MIRIWAY_XDG}:${XDG_CONFIG_DIRS:-/etc/xdg}"
 fi
 
 if command -v Xwayland > /dev/null

--- a/snap-utils/bin/miriway-session
+++ b/snap-utils/bin/miriway-session
@@ -1,4 +1,4 @@
 #!/bin/bash -l
 
-exec systemd-cat --identifier=miriway env MIRIWAY_SESSION_STARTUP="$SNAP/usr/libexec/miriway-session-startup-snap" MIRIWAY_SESSION_SHUTDOWN="$SNAP/usr/libexec/miriway-session-shutdown" miriway "$@"
+exec systemd-cat --identifier=$SNAP_INSTANCE_NAME env MIRIWAY_XDG=$SNAP_INSTANCE_NAME MIRIWAY_SESSION_STARTUP="$SNAP/usr/libexec/miriway-session-startup-snap" MIRIWAY_SESSION_SHUTDOWN="$SNAP/usr/libexec/miriway-session-shutdown" miriway "$@"
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,10 +1,10 @@
 #!/bin/sh -e
 
 mkdir -p /usr/share/wayland-sessions/ /usr/lib/systemd/user/
-sed -e s/miriway-session/miriway.session/ "$SNAP"/usr/share/wayland-sessions/miriway.desktop > /usr/share/wayland-sessions/miriway.desktop
+sed -e s/miriway-session/${SNAP_INSTANCE_NAME}.session/ -e "s/Name=.*/& ($SNAP_INSTANCE_KEY)/" "$SNAP"/usr/share/wayland-sessions/miriway.desktop > /usr/share/wayland-sessions/${SNAP_INSTANCE_NAME}.desktop
 cp "$SNAP"/usr/lib/systemd/user/miriway-session.target /usr/lib/systemd/user/
 
-xdg_config=/etc/xdg/xdg-miriway
+xdg_config=/etc/xdg/xdg-${SNAP_INSTANCE_NAME}
 
 miriway_config="${xdg_config}/miriway-shell.config"
 yambar_config="${xdg_config}/yambar/config.yml"
@@ -18,13 +18,13 @@ x11-window-title=Miriway
 idle-timeout=600
 app-env-amend=XDG_SESSION_TYPE=wayland:GTK_USE_PORTAL=0:XDG_CURRENT_DESKTOP=Miriway:GTK_A11Y=none
 
-ctrl-alt=t:miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/bin/miriway-terminal
+ctrl-alt=t:miriway-unsnap miriway-terminal
 shell-component=miriway-background
 shell-component=yambar --config="${yambar_config}"
 shell-component=swaync
-shell-component=/snap/${SNAP_INSTANCE_NAME}/usr/libexec/polkit-mate-authentication-agent-1
-shell-component=miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/bin/synapse --startup
-shell-meta=a:miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/bin/synapse
+shell-component=sh -c '\${SNAP}/usr/libexec/polkit-mate-authentication-agent-1'
+shell-component=miriway-unsnap synapse --startup
+shell-meta=a:miriway-unsnap synapse
 
 meta=Left:@dock-left
 meta=Right:@dock-right
@@ -57,7 +57,7 @@ bar:
           string:
             text: " start"
             margin: 5
-            on-click: miriway-unsnap /snap/${SNAP_INSTANCE_NAME}/current/usr/bin/synapse
+            on-click: miriway-unsnap synapse
             deco: &greybg
               background:
                 color: 3f3f3fff

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-rm /usr/share/wayland-sessions/miriway.desktop /etc/xdg/xdg-miriway/miriway-shell.config
-rm /usr/lib/systemd/user/miriway-session.target
+rm /usr/share/wayland-sessions/${SNAP_INSTANCE_NAME}.desktop
+rm /etc/xdg/xdg-${SNAP_INSTANCE_NAME}/miriway-shell.config
+# if we're the last ones, clear the target away
+if [[ $( snap list | grep -E "^${SNAP_NAME}[ _]" | wc -l ) -eq 1 ]]; then
+  rm /usr/lib/systemd/user/miriway-session.target
+fi


### PR DESCRIPTION
Something of an RFC still, but takes things close to allow `snap install miriway_foo` and have a full parallel session.

I didn't go as far as customizing the systemd target…