### PR TITLE
core26 (again)

### DIFF
--- a/example-configs/miriway-config-alan_g.bash
+++ b/example-configs/miriway-config-alan_g.bash
@@ -128,7 +128,7 @@ EOT
 # Ensure we have a config file with the fixed options
 cat <<EOT > "${yambar_config}"
 awesome: &awesome Font Awesome 6 Free:style=solid:pixelsize=14
-ubuntu: &ubuntu Font Ubuntu 6 Free:style=solid:pixelsize=14
+ubuntu: &ubuntu Ubuntu:pixelsize=14
 
 bar:
   location: top
@@ -177,7 +177,6 @@ EOT
 for wificard in /sys/class/net/wl*
 do cat <<EOT >> "${yambar_config}"
     - network:
-        name: $(basename "$wificard")
         content:
           map:
             deco: *greybg
@@ -189,12 +188,10 @@ do cat <<EOT >> "${yambar_config}"
                 map:
                   default:
                     - string: {text: , font: *awesome, deco: *greybg}
-#                    - string: {text: "{ssid} {dl-speed:mb}/{ul-speed:mb} Mb/s" }
 
                   conditions:
                     ipv4 == "":
                       - string: {text: , font: *awesome}
-#                      - string: {text: "{ssid} {dl-speed:mb}/{ul-speed:mb} Mb/s"}
 EOT
 done
 

--- a/example-configs/miriway-config-alan_g.bash
+++ b/example-configs/miriway-config-alan_g.bash
@@ -93,9 +93,9 @@ display-config=static=${miriway_display}
 lockscreen-app=miriway-unsnap swaylock -i ${background}
 
 shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice synapse --startup
-shell-component=systemd-run --user --scope --slice=background.slice swaybg --mode fill --output '*' --image ${background}
-shell-component=systemd-run --user --scope --slice=background.slice swaync
-shell-component=systemd-run --user --scope --slice=background.slice yambar
+shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice swaybg --mode fill --output '*' --image ${background}
+shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice swaync
+shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice yambar
 shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice gnome-keyring-daemon --foreground
 shell-component=miriway-unsnap systemd-run --user --scope --slice=background.slice ${polkit_agent}
 EOT

--- a/miriway-unsnap
+++ b/miriway-unsnap
@@ -3,10 +3,10 @@ set -e
 if [ "$SNAP_NAME" == "miriway" ]; then
   unset __EGL_VENDOR_LIBRARY_DIRS
   unset GBM_BACKENDS_PATH
-  unset LIBGL_DRIVERS_PATH
   unset LIBINPUT_QUIRKS_DIR
   unset DRIRC_CONFIGDIR
   unset XDG_DESKTOP_PORTAL_DIR
+  unset AMDGPU_ASIC_ID_TABLE_PATHS
 
   PATH="$(echo "$PATH" | sed "s#$SNAP[^:]*:##g")"
 fi

--- a/miriway-unsnap
+++ b/miriway-unsnap
@@ -3,6 +3,7 @@ set -e
 if [ "$SNAP_NAME" == "miriway" ]; then
   unset __EGL_VENDOR_LIBRARY_DIRS
   unset GBM_BACKENDS_PATH
+  unset LD_LIBRARY_PATH
   unset LIBINPUT_QUIRKS_DIR
   unset DRIRC_CONFIGDIR
   unset XDG_DESKTOP_PORTAL_DIR

--- a/snap-utils/bin/miriway-session
+++ b/snap-utils/bin/miriway-session
@@ -1,4 +1,5 @@
 #!/bin/bash -l
 
+PATH="$(echo "$PATH" | sed "s#$SNAP[^:]*:##g")"
 exec systemd-cat --identifier=miriway env MIRIWAY_SESSION_STARTUP="$SNAP/usr/libexec/miriway-session-startup-snap" MIRIWAY_SESSION_SHUTDOWN="$SNAP/usr/libexec/miriway-session-shutdown" miriway "$@"
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -43,7 +43,7 @@ EOT
 mkdir -p -m 755 "$(dirname "${yambar_config}")"
 cat <<EOT > "${yambar_config}"
 awesome: &awesome Font Awesome 6 Free:style=solid:pixelsize=14
-ubuntu: &ubuntu Font Ubuntu 6 Free:style=solid:pixelsize=14
+ubuntu: &ubuntu Ubuntu:pixelsize=14
 
 bar:
   location: top
@@ -76,7 +76,6 @@ EOT
 for wificard in /sys/class/net/wl*
 do cat <<EOT >> "${yambar_config}"
     - network:
-        name: $(basename "$wificard")
         content:
           map:
             deco: *greybg
@@ -88,12 +87,10 @@ do cat <<EOT >> "${yambar_config}"
                 map:
                   default:
                     - string: {text: , font: *awesome, deco: *greybg}
-#                    - string: {text: "{ssid} {dl-speed:mb}/{ul-speed:mb} Mb/s" }
 
                   conditions:
                     ipv4 == "":
                       - string: {text: , font: *awesome}
-#                      - string: {text: "{ssid} {dl-speed:mb}/{ul-speed:mb} Mb/s"}
 EOT
 done
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ issues: https://github.com/Miriway/Miriway/issues
 source-code: https://github.com/Miriway/Miriway
 
 confinement: classic
-base: core24
+base: core26
 
 platforms:
   amd64:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,8 +161,8 @@ parts:
       - -usr/include
       - -usr/lib/*/pkgconfig
       - -usr/lib/*/libmir*.so
-      # The libgallium* library needs no-patchelf, so it comes from the mesa-unpatched part
-      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
+      # The libLLVM.so* library needs no-patchelf, so it comes from the mesa-unpatched part
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so*
 
   example-configs:
     plugin: dump
@@ -186,11 +186,11 @@ parts:
   mesa-no-patchelf:
     plugin: nil
     stage-packages:
-      - mesa-libgallium
+      - libllvm21
     build-attributes:
       - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
     stage:
-      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so.*
 
   xdg-desktop-portal-wlr:
     plugin: meson
@@ -217,7 +217,7 @@ parts:
     stage-packages:
       - wayvnc
     stage:
-      # The libgallium* library needs no-patchelf, so it comes from the mesa-unpatched part
-      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
+      # The libLLVM.so* library needs no-patchelf, so it comes from the mesa-unpatched part
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so*
     build-attributes:
       - enable-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,6 @@ apps:
       MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/mir/server-platform
       __EGL_VENDOR_LIBRARY_DIRS: ${SNAP}/etc/glvnd/egl_vendor.d:${SNAP}/usr/share/glvnd/egl_vendor.d
       GBM_BACKENDS_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/gbm
-      LIBGL_DRIVERS_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
       LIBINPUT_QUIRKS_DIR: ${SNAP}/usr/share/libinput
       PATH: ${SNAP}/bin/:${SNAP}/usr/bin/:${SNAP}/usr/local/bin/:${PATH}
       # Warning: This variable is used by xdg-desktop-portal to force it to look in
@@ -54,6 +53,7 @@ apps:
       # but we are abusing it for our purposes here.
       XDG_DESKTOP_PORTAL_DIR: ${SNAP}/usr/share/xdg-desktop-portal/portals/
       DRIRC_CONFIGDIR: ${SNAP}/usr/share/drirc.d
+      AMDGPU_ASIC_ID_TABLE_PATHS: ${SNAP}/usr/share/libdrm${AMDGPU_ASIC_ID_TABLE_PATHS:+:$AMDGPU_ASIC_ID_TABLE_PATHS}
 
   session:
     command-chain: *command_chain
@@ -120,6 +120,8 @@ parts:
       - yambar
       # And try to get _all_ the mesa drivers
       - libgl1-mesa-dri
+      - libdrm2
+      - libdrm-common
       - libdrm-nouveau2
       - libdrm-amdgpu1
       - libdrm-radeon1
@@ -148,7 +150,6 @@ parts:
       - -usr/share/doc
       - -usr/share/doc-base
       - -usr/share/icons
-      - -usr/share/libdrm
       - -usr/share/libwacom
       - -usr/share/lintian
       - -usr/share/man

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,9 +57,7 @@ apps:
       AMDGPU_ASIC_ID_TABLE_PATHS: ${SNAP}/usr/share/libdrm${AMDGPU_ASIC_ID_TABLE_PATHS:+:$AMDGPU_ASIC_ID_TABLE_PATHS}
 
   session:
-    command-chain: *command_chain
     command: bin/miriway-session
-    environment: *_environment
 
   vnc-server:
     command-chain:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ apps:
       MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/mir/server-platform
       __EGL_VENDOR_LIBRARY_DIRS: ${SNAP}/etc/glvnd/egl_vendor.d:${SNAP}/usr/share/glvnd/egl_vendor.d
       GBM_BACKENDS_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/gbm
+      LD_LIBRARY_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
       LIBINPUT_QUIRKS_DIR: ${SNAP}/usr/share/libinput
       PATH: ${SNAP}/bin/:${SNAP}/usr/bin/:${SNAP}/usr/local/bin/:${PATH}
       # Warning: This variable is used by xdg-desktop-portal to force it to look in

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,6 +161,8 @@ parts:
       - -usr/include
       - -usr/lib/*/pkgconfig
       - -usr/lib/*/libmir*.so
+      # The libgallium* library needs no-patchelf, so it comes from the mesa-unpatched part
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
       # The libLLVM.so* library needs no-patchelf, so it comes from the mesa-unpatched part
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so*
 
@@ -186,10 +188,12 @@ parts:
   mesa-no-patchelf:
     plugin: nil
     stage-packages:
+      - mesa-libgallium
       - libllvm21
     build-attributes:
       - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
     stage:
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
       - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so.*
 
   xdg-desktop-portal-wlr:
@@ -217,6 +221,8 @@ parts:
     stage-packages:
       - wayvnc
     stage:
+      # The libgallium* library needs no-patchelf, so it comes from the mesa-unpatched part
+      - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libgallium*
       # The libLLVM.so* library needs no-patchelf, so it comes from the mesa-unpatched part
       - -usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libLLVM.so*
     build-attributes:


### PR DESCRIPTION
Migrate the Miriway snap to `base: core26`. (This is mostly figuring out how to repackage Mesa in a classic snap.)